### PR TITLE
feat(goods): グッズを売り切れ状態に変更 & リンク無効化

### DIFF
--- a/data/goods.json
+++ b/data/goods.json
@@ -3,36 +3,36 @@
     "name": "伊吹しろうデビュー記念フルセット",
     "thumbnail": "assets/goods/20251118_matome.webp",
     "link": "https://ibukishirou.booth.pm/items/7618604",
-    "available": true
+    "available": false
   },
   {
     "name": "アクリルスタンド",
     "thumbnail": "assets/goods/20251118_akusuta.webp",
     "link": "https://ibukishirou.booth.pm/items/7625265",
-    "available": true
+    "available": false
   },
   {
     "name": "アクリルキーホルダー",
     "thumbnail": "assets/goods/20251118_akuki.webp",
     "link": "https://ibukishirou.booth.pm/items/7625274",
-    "available": true
+    "available": false
   },
   {
     "name": "ステッカー10枚セット",
     "thumbnail": "assets/goods/20251118_sticker.webp",
     "link": "https://ibukishirou.booth.pm/items/7625278",
-    "available": true
+    "available": false
   },
   {
     "name": "三連アクリルキーホルダー",
     "thumbnail": "assets/goods/20251118_3akuki.webp",
     "link": "https://ibukishirou.booth.pm/items/7625282",
-    "available": true
+    "available": false
   },
   {
     "name": "缶バッチ",
     "thumbnail": "assets/goods/20251118_kanbatti.webp",
     "link": "https://ibukishirou.booth.pm/items/7625284",
-    "available": true
+    "available": false
   }
 ]

--- a/js/fetch-goods.js
+++ b/js/fetch-goods.js
@@ -23,6 +23,22 @@ function displayGoods(goodsArray) {
     const availableClass = item.available ? '' : 'sold-out';
     const soldOutOverlay = !item.available ? '<div class="sold-out-overlay">Sold Out</div>' : '';
     
+    // availableがfalseの場合はdivタグを使用（リンク無効化）
+    if (!item.available) {
+      return `
+        <div class="card goods-card ${availableClass}" style="cursor: not-allowed;">
+          <div class="goods-image-wrapper">
+            <img src="${item.thumbnail}" alt="${item.name}" class="card-image" onerror="if(!this.dataset.failed){this.dataset.failed='1';this.src='assets/img/placeholder.webp';}else{this.style.display='none';}">
+            ${soldOutOverlay}
+          </div>
+          <div class="card-content">
+            <h3 class="card-title">${item.name}</h3>
+          </div>
+        </div>
+      `;
+    }
+    
+    // availableがtrueの場合は通常のリンク
     return `
       <a href="${item.link}" target="_blank" class="card goods-card ${availableClass}">
         <div class="goods-image-wrapper">


### PR DESCRIPTION
## 📋 変更概要

全グッズを売り切れ状態に変更し、売り切れグッズはクリックしてもリンクに飛ばないように改善しました。

## 🎯 主な変更内容

### 1. グッズデータの更新（goods.json）
- 全6アイテムの `available` を `false` に変更
  - 伊吹しろうデビュー記念フルセット
  - アクリルスタンド
  - アクリルキーホルダー
  - ステッカー10枚セット
  - 三連アクリルキーホルダー
  - 缶バッチ

### 2. グッズ表示ロジックの改善（fetch-goods.js）
- `available: false` の場合：
  - `<a>` タグではなく `<div>` タグを使用
  - リンクが無効化され、クリックしても遷移しない
  - `cursor: not-allowed` でUX改善
  - 「Sold Out」オーバーレイ表示

- `available: true` の場合：
  - 通常通り `<a>` タグでリンク有効
  - BOOTHの商品ページへ遷移可能

## 🎨 ユーザー体験の向上

### Before（問題点）
- 売り切れグッズをクリックすると、BOOTHの「販売終了」ページに飛んでしまう
- ユーザーが期待を持ってクリックするが、購入できずがっかり

### After（改善点）
- ✅ 売り切れグッズはクリック不可
- ✅ カーソルが "not-allowed" アイコンに変化
- ✅ 「Sold Out」オーバーレイで視覚的に明確
- ✅ 不要なページ遷移を防止

## 🔍 技術的な詳細

### 条件分岐ロジック
```javascript
if (!item.available) {
  // divタグで非リンク化
  return `<div class="card goods-card sold-out" style="cursor: not-allowed;">...</div>`;
} else {
  // aタグで通常リンク
  return `<a href="${item.link}" target="_blank" class="card goods-card">...</a>`;
}
```

### スタイリング
- `cursor: not-allowed`: ホバー時に禁止アイコン表示
- `sold-out` クラス: 既存のsold-outスタイルを適用
- `sold-out-overlay`: 「Sold Out」テキストオーバーレイ

## 📝 今後の運用

### グッズ再販時の対応
1. `data/goods.json` を開く
2. 再販するアイテムの `available` を `true` に変更
3. 変更をコミット・プッシュ

### 新規グッズ追加時
```json
{
  "name": "新グッズ名",
  "thumbnail": "assets/goods/image.webp",
  "link": "https://ibukishirou.booth.pm/items/xxxxx",
  "available": true
}
```

---

**制作日**: 2025年1月19日  
**担当**: GenSpark AI Developer