### PR TITLE
fix(profile): SPビューでの名前表示の改行を修正

### DIFF
--- a/css/profile.css
+++ b/css/profile.css
@@ -95,3 +95,16 @@
   color: var(--color-text-secondary);
   white-space: nowrap;
 }
+
+/* プロフィール名の英語部分 - SPビューで改行制御 */
+.profile-name-en {
+  white-space: nowrap;
+}
+
+/* SPビュー: 伊吹しろうの後で改行 */
+@media (max-width: 768px) {
+  .profile-name-en {
+    display: block;
+    margin-top: 0.3rem;
+  }
+}

--- a/profile.html
+++ b/profile.html
@@ -82,7 +82,7 @@
       <div class="profile-info">
         <!-- 伊吹しろうセクション -->
         <div class="profile-section-group">
-          <h1 class="profile-name">伊吹しろう <span style="color: var(--color-text); font-size: 0.8em; font-weight: 400;">Ibuki Shirou</span></h1>
+          <h1 class="profile-name">伊吹しろう <span class="profile-name-en" style="color: var(--color-text); font-size: 0.8em; font-weight: 400;">Ibuki Shirou</span></h1>
           <p style="font-family: var(--font-secondary); color: var(--color-secondary); margin-bottom: 1rem; line-height: 1.8; font-weight: 700; font-size: 1.15rem;">
             歌とトークで君を虜にするVTuber。<br>
             一瞬を楽しむだけじゃない、君の記憶に深く刻まれる存在へ。<br>


### PR DESCRIPTION
## 修正内容

プロフィールページのSPビュー表示において、「伊吹しろう Ibuki Shirou」の改行位置を修正しました。

### 問題
- SPビューで「伊吹しろう Ibuki」で改行され、「Shirou」が次の行に表示されていた
- 「Ibuki Shirou」が分割されて不格好な表示になっていた

### 修正内容
1. **HTMLの変更**
   - `profile-name-en`クラスを追加して英語名部分を識別

2. **CSSの追加**
   - `.profile-name-en`に`white-space: nowrap`を設定し、「Ibuki Shirou」が分割されないよう制御
   - SPビュー（max-width: 768px）では`display: block`を適用し、「伊吹しろう」の後で改行

### 表示結果
**PCビュー**: 
```
伊吹しろう Ibuki Shirou （1行表示）
```

**SPビュー**:
```
伊吹しろう
Ibuki Shirou （2行目に完全に表示）
```

これにより、SPビューでもきれいな改行が実現されます。