### PR TITLE
feat(calendar): 記念日（誕生日・デビュー日）機能を追加

### DIFF
--- a/data/calendar.json
+++ b/data/calendar.json
@@ -1,22 +1,38 @@
 {
-  "regular": [
-    {
-      "title": "朝活",
-      "start_time": "07:30",
-      "end_time": "10:30",
-      "link": "https://www.youtube.com/@ibukishirou/streams",
-      "tags": ["配信"],
-      "days": {
-        "sunday": true,
-        "monday": true,
-        "tuesday": true,
-        "wednesday": true,
-        "thursday": false,
-        "friday": true,
-        "saturday": true
+  "regular": {
+    "scheduled": [
+      {
+        "title": "朝活",
+        "start_time": "07:30",
+        "end_time": "10:30",
+        "link": "https://www.youtube.com/@ibukishirou/streams",
+        "tags": ["配信"],
+        "days": {
+          "sunday": true,
+          "monday": true,
+          "tuesday": true,
+          "wednesday": true,
+          "thursday": false,
+          "friday": true,
+          "saturday": true
+        }
       }
-    }
-  ],
+    ],
+    "celebration": [
+      {
+        "title": "誕生日",
+        "date": "03-22",
+        "link": "https://www.youtube.com/@ibukishirou",
+        "tags": ["記念"]
+      },
+      {
+        "title": "デビュー日",
+        "date": "09-22",
+        "link": "https://www.youtube.com/@ibukishirou",
+        "tags": ["記念"]
+      }
+    ]
+  },
   "events": [
     {
       "title": "決算配信",


### PR DESCRIPTION
## 概要
記念日（誕生日・デビュー日）を毎年カレンダーに表示する機能を追加しました。

## 変更内容

### 1. データ構造の変更 (`calendar.json`)
- `regular` を `scheduled` と `celebration` に分割
- `scheduled`: 定期配信（従来の内容）
- `celebration`: 記念日イベント
  - 誕生日: 3月22日
  - デビュー日: 9月22日

### 2. 表示ロジックの実装 (`calendar.js`)
- 記念日を毎年カレンダーに自動表示
- 表示色: `#dc143c` (crimson、赤色)
- 終日イベントとして扱い
- フィルター対象外（常に表示）
- モーダル表示にも対応

## 仕様
- **日付フォーマット**: `MM-DD` (例: `03-22`)
- **時刻**: 終日イベント（時刻なし）
- **表示色**: `#dc143c` (crimson)
- **フィルター**: 対象外（常に表示）

## テスト
- [x] JSONシンタックスチェック
- [x] JavaScriptシンタックスチェック
- [x] 記念日処理ロジックの実装確認
- [x] モーダル表示の対応確認

## 関連ファイル
- `data/calendar.json`
- `js/calendar.js`