### PR TITLE
feat(achievements): achievement-contentカード全体をクリッカブルに改修

### DIFF
--- a/css/achievements.css
+++ b/css/achievements.css
@@ -137,6 +137,11 @@
   transition: var(--transition);
 }
 
+/* クリッカブルなコンテンツ */
+.achievement-content.clickable {
+  cursor: pointer;
+}
+
 .achievement-item:nth-child(odd) .achievement-content {
   margin-left: 55%;
 }
@@ -159,16 +164,6 @@
   color: var(--color-text);
   line-height: 1.6;
   margin: 0 0 0.75rem 0;
-}
-
-.achievement-title a {
-  color: var(--color-text);
-  text-decoration: none;
-  transition: var(--transition);
-}
-
-.achievement-title a:hover {
-  color: var(--color-secondary);
 }
 
 /* 本文 */

--- a/js/fetch-achievements.js
+++ b/js/fetch-achievements.js
@@ -70,10 +70,8 @@ function displayAchievements(achievementsArray) {
         <div class="achievement-item">
           <div class="achievement-date">${formattedDate}</div>
           <div class="achievement-point"></div>
-          <div class="achievement-content" data-date="${formattedDate}">
-            <h3 class="achievement-title">
-              <a href="${item.link}" target="_blank" rel="noopener noreferrer">${item.title}</a>
-            </h3>
+          <div class="achievement-content clickable" data-date="${formattedDate}" data-link="${item.link}">
+            <h3 class="achievement-title">${item.title}</h3>
             <p class="achievement-body">${item.body}</p>
             <div class="achievement-tags">${tagsHTML}</div>
           </div>
@@ -93,6 +91,19 @@ function displayAchievements(achievementsArray) {
       `;
     }
   }).join('');
+  
+  // クリッカブルなコンテンツにクリックイベントを追加
+  setTimeout(() => {
+    const clickableCards = document.querySelectorAll('.achievement-content.clickable');
+    clickableCards.forEach(card => {
+      card.addEventListener('click', (e) => {
+        const link = card.dataset.link;
+        if (link) {
+          window.open(link, '_blank', 'noopener,noreferrer');
+        }
+      });
+    });
+  }, 100);
 }
 
 // ページ読み込み時に実行


### PR DESCRIPTION
## 概要
Achievementsページのachievement-contentカード全体をクリックしてリンクに遷移できるように改修しました。

## 変更内容

### 1. JavaScript (`js/fetch-achievements.js`)
- リンク付きのコンテンツに `clickable` クラスを追加
- `data-link` 属性にリンクURLを格納
- カード全体にクリックイベントリスナーを追加
- クリック時に新しいタブでリンクを開く処理を実装

### 2. CSS (`css/achievements.css`)
- `.achievement-content.clickable` にポインターカーソルを適用
- タイトルのリンク用スタイルを削除（不要になったため）

## 改善点
- ✅ **UX向上**: カードのどこをクリックしても反応するため、クリック可能な領域が大幅に拡大
- ✅ **直感的な操作**: タイトルだけでなくカード全体がクリッカブルに
- ✅ **視覚的フィードバック**: カーソルがポインターに変わることでクリック可能であることを明示

## 動作
- **リンクあり**: カード全体をクリックすると新しいタブでリンクが開く
- **リンクなし**: 従来通りクリック不可（ポインターカーソルも表示されない）

## テスト
- [x] JavaScriptシンタックスチェック
- [x] クリックイベントの実装確認
- [x] CSSスタイルの適用確認

## 関連ファイル
- `js/fetch-achievements.js`
- `css/achievements.css`