### PR TITLE
feat: Songsスクロール動作を「停止→先頭に戻る」方式に変更

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,6 +415,7 @@ section {
 /* Featured Works専用: 横スクロールレイアウト */
 #featured-works .card-grid {
   display: flex;
+  flex-wrap: nowrap;
   grid-template-columns: unset;
   gap: 2rem;
   overflow-x: auto;

--- a/index.html
+++ b/index.html
@@ -176,7 +176,13 @@
   <script src="js/main.js"></script>
   <script src="js/fetch-links.js"></script>
   <script>
-    // Featured Worksの読み込み
+    // YouTube動画IDを抽出
+    function extractYouTubeVideoId(url) {
+      const match = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([^&?\/\s]+)/);
+      return match ? match[1] : '';
+    }
+    
+    // Featured Worksの読み込み完了を待ってからスクロールを開始
     async function loadFeaturedWorks() {
       try {
         const response = await fetch('data/works.json');
@@ -203,121 +209,114 @@
             </a>
           `;
         }).join('');
+        
+        // コンテンツ読み込み完了後、画像の読み込みを待つ
+        const images = container.querySelectorAll('img');
+        await Promise.all(Array.from(images).map(img => {
+          if (img.complete) return Promise.resolve();
+          return new Promise(resolve => {
+            img.onload = resolve;
+            img.onerror = resolve;
+          });
+        }));
+        
+        // 自動スクロール開始
+        initAutoScroll();
+        
       } catch (error) {
         console.error('Featured Worksの読み込みに失敗しました:', error);
       }
     }
     
-    loadFeaturedWorks();
-  </script>
-  <script>
-    // Featured Worksのスクロール機能（スクロール→停止3秒→先頭に戻る→繰り返し）
-    (function() {
-      let isScrolling = false;
-      let isPausedByUser = false;
-      let isWaitingAtEnd = false;
-      const scrollSpeed = 0.5; // ピクセル/フレーム（ゆっくり）
-      const pauseDuration = 3000; // 停止時間: 3秒
-      let container = null;
+    // Featured Worksのスクロール機能（スクロール→停止3秒→アニメーションで先頭に戻る→繰り返し）
+    function initAutoScroll() {
+      const container = document.getElementById('featured-works-container');
+      if (!container) {
+        console.error('❌ Container not found');
+        return;
+      }
       
-      function startAutoScroll() {
-        container = document.getElementById('featured-works-container');
-        if (!container || isScrolling) return;
+      // DOM再描画を待つ
+      setTimeout(() => {
+        // 初期状態のログ
+        console.log('=== Auto-scroll initialization ===');
+        console.log('Container:', container);
+        console.log('Children count:', container.children.length);
+        console.log('scrollWidth:', container.scrollWidth);
+        console.log('clientWidth:', container.clientWidth);
+        console.log('maxScrollLeft:', container.scrollWidth - container.clientWidth);
         
-        isScrolling = true;
-        isPausedByUser = false;
-        isWaitingAtEnd = false;
+        // コンテンツが存在しない場合は中止
+        if (container.scrollWidth <= container.clientWidth) {
+          console.warn('⚠️  No scrollable content. Retrying in 500ms...');
+          // リトライ
+          setTimeout(() => initAutoScroll(), 500);
+          return;
+        }
+        
+        console.log('✅ Starting auto-scroll with scrollable content');
+        
+        let isScrolling = true;
+        let isPausedByUser = false;
+        let isWaitingAtEnd = false;
+        let isReturningToStart = false;
+        const scrollSpeed = 0.5; // ピクセル/フレーム
+        const pauseDuration = 3000; // 停止時間: 3秒
+        const returnDuration = 800; // 先頭に戻るアニメーション時間: 0.8秒
         
         function scroll() {
-          if (!isPausedByUser && !isWaitingAtEnd && container) {
-            // 毎フレーム最大スクロール位置を再計算（コンテンツサイズ変動対応）
+          if (!isScrolling) return;
+          
+          if (!isPausedByUser && !isWaitingAtEnd && !isReturningToStart) {
             const maxScrollLeft = container.scrollWidth - container.clientWidth;
-            
             container.scrollLeft += scrollSpeed;
             
-            // 最後まで到達したら一時停止（少しマージンを持たせる）
-            if (container.scrollLeft >= maxScrollLeft - 5) {
+            // 最後まで到達したら停止
+            if (container.scrollLeft >= maxScrollLeft - 1) {
               isWaitingAtEnd = true;
-              console.log('Reached end, waiting 3 seconds...');
+              console.log('✓ Reached end. Waiting 3 seconds... (scrollLeft:', container.scrollLeft, ')');
               
-              // 3秒後に先頭に戻る
+              // 3秒後に先頭に戻るアニメーション開始
               setTimeout(() => {
-                if (container && isWaitingAtEnd) {
-                  console.log('Returning to start');
-                  container.scrollLeft = 0;
-                  isWaitingAtEnd = false;
-                }
+                if (!isScrolling) return;
+                
+                isWaitingAtEnd = false;
+                isReturningToStart = true;
+                console.log('✓ Starting return animation');
+                
+                // スムーズスクロールで先頭に戻る
+                container.style.scrollBehavior = 'smooth';
+                container.scrollLeft = 0;
+                
+                // アニメーション完了後、スクロール再開
+                setTimeout(() => {
+                  container.style.scrollBehavior = 'auto';
+                  isReturningToStart = false;
+                  console.log('✓ Returned to start. Resuming scroll...');
+                }, returnDuration);
+                
               }, pauseDuration);
             }
           }
           
-          if (isScrolling) {
-            requestAnimationFrame(scroll);
-          }
+          requestAnimationFrame(scroll);
         }
         
+        // ユーザーインタラクション
+        container.addEventListener('mousedown', () => { isPausedByUser = true; });
+        container.addEventListener('mouseup', () => { isPausedByUser = false; });
+        container.addEventListener('touchstart', () => { isPausedByUser = true; }, { passive: true });
+        container.addEventListener('touchend', () => { isPausedByUser = false; }, { passive: true });
+        container.addEventListener('touchcancel', () => { isPausedByUser = false; }, { passive: true });
+        container.addEventListener('mouseenter', () => { isPausedByUser = true; });
+        container.addEventListener('mouseleave', () => { isPausedByUser = false; });
+      
+        // スクロール開始
         requestAnimationFrame(scroll);
-      }
-      
-      function stopAutoScroll() {
-        isScrolling = false;
-        isPausedByUser = false;
-        isWaitingAtEnd = false;
-      }
-      
-      function pauseAutoScroll() {
-        isPausedByUser = true;
-      }
-      
-      function resumeAutoScroll() {
-        isPausedByUser = false;
-      }
-      
-      // DOMが読み込まれたら自動スクロール開始
-      function initAutoScroll() {
-        container = document.getElementById('featured-works-container');
-        if (!container) return;
-        
-        console.log('Initializing auto-scroll for Songs section');
-        
-        // マウスイベント（PC）
-        container.addEventListener('mousedown', (e) => {
-          pauseAutoScroll();
-        });
-        
-        container.addEventListener('mouseup', (e) => {
-          resumeAutoScroll();
-        });
-        
-        // タッチイベント（スマホ/タブレット）
-        container.addEventListener('touchstart', (e) => {
-          pauseAutoScroll();
-        }, { passive: true });
-        
-        container.addEventListener('touchend', (e) => {
-          resumeAutoScroll();
-        }, { passive: true });
-        
-        container.addEventListener('touchcancel', (e) => {
-          resumeAutoScroll();
-        }, { passive: true });
-        
-        // ホバー時にもストップ（PC）
-        container.addEventListener('mouseenter', (e) => {
-          pauseAutoScroll();
-        });
-        
-        container.addEventListener('mouseleave', (e) => {
-          resumeAutoScroll();
-        });
-        
-        // 自動スクロール開始
-        startAutoScroll();
-      }
-      
-      // ページ読み込み後に実行（Featured Worksが読み込まれた後）
-      setTimeout(initAutoScroll, 1000);
-    })();
+      }, 100); // 100msの遅延で初期化
+    }
+    
+    loadFeaturedWorks();
   </script>
   <script src="js/share.js"></script>
   <script src="js/sw-register.js"></script>

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 // Service Worker - 伊吹しろう Official Website
 // ============================================
 
-const CACHE_VERSION = 'v1.0.4';
+const CACHE_VERSION = 'v1.0.5';
 const CACHE_NAME = `ibukishirou-${CACHE_VERSION}`;
 
 // キャッシュするリソース


### PR DESCRIPTION
## 変更内容

### スクロール動作の仕様変更

**変更前**:
- シームレスな無限スクロール
- コンテンツを3回複製して連結
- 永遠にスクロールし続けているように見える

**変更後**:
1. 右から左へゆっくりスクロール（0.5px/frame）
2. 最後まで到達
3. **3秒間停止**
4. 先頭に瞬時に戻る
5. 1に戻って繰り返し

### 実装詳細

**削除した処理**:
- `cloneContent()` 関数（コンテンツ複製処理）
- `originalWidth` 変数（オリジナル幅の記録）

**追加・変更した処理**:
- `maxScrollLeft` 変数: 最大スクロール位置を計算
- 最後まで到達時に `isPaused = true` で一時停止
- `setTimeout()` で3秒後（`pauseDuration: 3000ms`）に先頭に戻る
- `container.scrollLeft = 0` で先頭位置にリセット
- 自動的に `isPaused = false` でスクロール再開

**維持した機能**:
- ユーザーインタラクション時の一時停止機能
  - PC: マウスダウン/ホバーで停止、マウスアップ/マウスリーブで再開
  - スマホ/タブレット: タッチで停止、離して再開

### Service Worker
- バージョン更新: v1.0.3 → v1.0.4

## テスト確認項目
- [ ] Songsセクションが右から左にゆっくりスクロールする
- [ ] 最後まで到達したら3秒間停止する
- [ ] 3秒後に先頭に戻る
- [ ] 先頭に戻った後、自動的にスクロールを再開する
- [ ] PC: マウスダウン/ホバーで一時停止する
- [ ] PC: マウスアップ/マウスリーブでスクロール再開する
- [ ] スマホ/タブレット: タッチで一時停止する
- [ ] スマホ/タブレット: 離してスクロール再開する

## 備考
- コンテンツの複製がなくなったため、DOMがシンプルになりメモリ使用量が削減されました
- 3秒の停止時間はユーザーがコンテンツを確認する時間として設定しています