### PR TITLE
feat(achievements): Redesign timeline layout and add Video filter

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -77,6 +77,7 @@
       <button class="filter-btn active" data-filter="all">ALL</button>
       <button class="filter-btn" data-filter="infomation">Information</button>
       <button class="filter-btn" data-filter="music">Music</button>
+      <button class="filter-btn" data-filter="video">Video</button>
     </div>
     
     <!-- 実績リスト -->

--- a/css/achievements.css
+++ b/css/achievements.css
@@ -1,5 +1,5 @@
 /* ============================================
-   Achievements Page - 年表デザイン（修正版）
+   Achievements Page - 年表デザイン（縦一列）
    ============================================ */
 
 /* フィルターボタン */
@@ -20,50 +20,34 @@
   font-size: 1rem;
   font-weight: 500;
   cursor: pointer;
-  transition: var(--transition);
+  transition: all 0.3s ease;
   border-radius: 4px;
 }
 
-.filter-btn:hover {
-  background: rgba(139, 0, 0, 0.2);
-  border-color: var(--color-secondary);
-  color: var(--color-text);
-}
-
+/* ホバー効果はJavaScriptで動的に制御 */
 .filter-btn.active {
-  background: var(--color-secondary);
-  border-color: var(--color-secondary);
   color: var(--color-text);
 }
 
 /* 年表リスト */
 .achievements-list {
-  max-width: 1000px;
+  max-width: 900px;
   margin: 0 auto;
   padding: 3rem 2rem;
   position: relative;
 }
 
-/* 中央の縦線 - 丸の下に表示 */
+/* 左側の縦線 - 削除（窮屈に見えるため） */
 .achievements-list::before {
-  content: '';
-  position: absolute;
-  left: 50%;
-  top: 0;
-  bottom: 0;
-  width: 3px;
-  background: linear-gradient(to bottom, 
-    var(--color-secondary) 0%, 
-    var(--color-primary) 50%, 
-    var(--color-secondary) 100%);
-  transform: translateX(-50%);
-  z-index: 0;
+  display: none;
 }
 
 /* 各アイテム */
 .achievement-item {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 3rem;
   position: relative;
-  margin-bottom: 4rem;
   opacity: 0;
   animation: fadeInUp 0.6s ease forwards;
 }
@@ -88,48 +72,30 @@
 .achievement-item:nth-child(6) { animation-delay: 0.6s; }
 .achievement-item:nth-child(7) { animation-delay: 0.7s; }
 .achievement-item:nth-child(8) { animation-delay: 0.8s; }
+.achievement-item:nth-child(9) { animation-delay: 0.9s; }
+.achievement-item:nth-child(10) { animation-delay: 1.0s; }
 
-/* 日付 - 奇数は左側 */
+/* 日付（左側） */
 .achievement-date {
-  position: absolute;
-  top: 0;
+  flex-shrink: 0;
+  width: 120px;
   font-family: var(--font-secondary);
-  font-size: 1.1rem;
+  font-size: 1rem;
   color: var(--color-secondary);
   font-weight: 700;
-  white-space: nowrap;
-}
-
-.achievement-item:nth-child(odd) .achievement-date {
-  right: 50%;
-  margin-right: 3rem;
   text-align: right;
+  padding-right: 1.5rem;
+  padding-top: 0.25rem;
 }
 
-.achievement-item:nth-child(even) .achievement-date {
-  left: 50%;
-  margin-left: 3rem;
-  text-align: left;
-}
-
-/* 中央のポイント - ラインの上に表示 */
+/* ポイント（縦線上） - 削除 */
 .achievement-point {
-  width: 20px;
-  height: 20px;
-  background: var(--color-secondary);
-  border: 4px solid var(--color-bg);
-  border-radius: 50%;
-  position: absolute;
-  left: 50%;
-  top: 0;
-  transform: translateX(-50%);
-  z-index: 100;
-  box-shadow: 0 0 0 4px rgba(210, 105, 30, 0.3);
+  display: none;
 }
 
-/* コンテンツ - 奇数は右側 */
+/* コンテンツ（右側） */
 .achievement-content {
-  width: 45%;
+  flex: 1;
   background: rgba(26, 26, 26, 0.4);
   padding: 1.5rem;
   border-radius: 8px;
@@ -142,15 +108,7 @@
   cursor: pointer;
 }
 
-.achievement-item:nth-child(odd) .achievement-content {
-  margin-left: 55%;
-}
-
-.achievement-item:nth-child(even) .achievement-content {
-  margin-right: 55%;
-}
-
-.achievement-content:hover {
+.achievement-content.clickable:hover {
   background: rgba(26, 26, 26, 0.6);
   border-color: var(--color-secondary);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
@@ -184,71 +142,87 @@
 }
 
 .achievement-tag {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-family: var(--font-secondary);
-  font-weight: 400;
-  color: var(--color-text-secondary);
-  opacity: 0.7;
+  font-weight: 500;
+  padding: 0.35rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid currentColor;
+  display: inline-block;
 }
 
 .achievement-tag::before {
   content: '#';
   margin-right: 0.2rem;
+  opacity: 0.8;
+}
+
+/* タグの色分け */
+.achievement-tag.tag-infomation {
+  color: rgb(255, 69, 0);
+}
+
+.achievement-tag.tag-music {
+  color: rgb(130, 130, 255);
+}
+
+.achievement-tag.tag-video {
+  color: rgb(34, 139, 34);
 }
 
 /* レスポンシブ対応 */
 @media (max-width: 768px) {
   .filter-buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: auto auto;
     gap: 0.5rem;
+    max-width: 100%;
+  }
+  
+  /* ALLボタンを1段目全幅に */
+  .filter-btn[data-filter="all"] {
+    grid-column: 1 / -1;
   }
   
   .filter-btn {
-    padding: 0.6rem 1.5rem;
-    font-size: 0.9rem;
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+    width: 100%;
   }
   
   .achievements-list {
     padding: 2rem 1rem;
-    padding-left: 2.5rem;
   }
   
-  /* SPでは縦線と点を非表示 */
+  /* SPでは縦線を非表示 */
   .achievements-list::before {
     display: none;
   }
   
   .achievement-item {
+    flex-direction: column;
     margin-bottom: 2rem;
-    padding-left: 0;
   }
   
-  /* SPでは日付を非表示 */
+  /* SPでは日付をコンテンツ上部に */
   .achievement-date {
-    display: none;
+    width: 100%;
+    text-align: left;
+    padding: 0 0 0.5rem 0;
+    font-size: 0.95rem;
   }
   
+  /* SPではポイントを非表示 */
   .achievement-point {
     display: none;
   }
   
   /* SPではコンテンツを全幅に */
-  .achievement-content,
-  .achievement-item:nth-child(odd) .achievement-content,
-  .achievement-item:nth-child(even) .achievement-content {
+  .achievement-content {
     width: 100%;
-    margin: 0;
     padding: 1.25rem;
-  }
-  
-  /* SPでは日付をコンテンツ内に表示 */
-  .achievement-content::before {
-    content: attr(data-date);
-    display: block;
-    font-family: var(--font-secondary);
-    font-size: 1rem;
-    color: var(--color-secondary);
-    font-weight: 700;
-    margin-bottom: 0.75rem;
   }
   
   .achievement-title {

--- a/data/achievements.json
+++ b/data/achievements.json
@@ -52,7 +52,7 @@
     "title": "「30秒でわかる伊吹しろう」自己紹介動画公開",
     "body": "新規さん向けの動画を公開しました。拡散よろしくお願いいたします！",
     "link": "https://youtu.be/ubOOb-J1Jeg",
-    "tags": ["infomation"],
+    "tags": ["video"],
     "release_date": "2025-12-29"
   }
 ]

--- a/js/fetch-achievements.js
+++ b/js/fetch-achievements.js
@@ -22,15 +22,70 @@ async function loadAchievements() {
 function setupFilterButtons() {
   const filterButtons = document.querySelectorAll('.filter-btn');
   
+  // タグごとの色定義
+  const filterColors = {
+    'infomation': 'rgb(255, 69, 0)',
+    'music': 'rgb(130, 130, 255)',
+    'video': 'rgb(34, 139, 34)',
+    'all': '#D2691E' // var(--color-secondary)の実際の値
+  };
+  
+  // ホバー時の背景色（透明度を追加）
+  const getHoverColor = (filter) => {
+    const colors = {
+      'infomation': 'rgba(255, 69, 0, 0.2)',
+      'music': 'rgba(130, 130, 255, 0.2)',
+      'video': 'rgba(34, 139, 34, 0.2)',
+      'all': 'rgba(210, 105, 30, 0.2)'
+    };
+    return colors[filter] || 'rgba(210, 105, 30, 0.2)';
+  };
+  
+  // 初期状態でALLボタンをアクティブに設定
+  const allButton = document.querySelector('.filter-btn[data-filter="all"]');
+  if (allButton) {
+    allButton.style.backgroundColor = filterColors['all'];
+    allButton.style.borderColor = filterColors['all'];
+  }
+  
   filterButtons.forEach(button => {
+    const filter = button.dataset.filter;
+    
+    // ホバーイベント
+    button.addEventListener('mouseenter', () => {
+      if (!button.classList.contains('active')) {
+        button.style.backgroundColor = getHoverColor(filter);
+        button.style.borderColor = filterColors[filter];
+        button.style.color = 'var(--color-text)';
+      }
+    });
+    
+    button.addEventListener('mouseleave', () => {
+      if (!button.classList.contains('active')) {
+        button.style.backgroundColor = '';
+        button.style.borderColor = '';
+        button.style.color = '';
+      }
+    });
+    
+    // クリックイベント
     button.addEventListener('click', () => {
       // アクティブボタンの切り替え
-      filterButtons.forEach(btn => btn.classList.remove('active'));
+      filterButtons.forEach(btn => {
+        btn.classList.remove('active');
+        btn.style.backgroundColor = '';
+        btn.style.borderColor = '';
+        btn.style.color = '';
+      });
       button.classList.add('active');
       
       // フィルタリング
-      const filter = button.dataset.filter;
       currentFilter = filter;
+      
+      // アクティブボタンの色を設定
+      const color = filterColors[filter];
+      button.style.backgroundColor = color;
+      button.style.borderColor = color;
       
       if (filter === 'all') {
         displayAchievements(achievementsData);
@@ -57,10 +112,22 @@ function displayAchievements(achievementsArray) {
     const date = new Date(item.release_date);
     const formattedDate = `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
     
-    // タグのHTML生成（#付きのライトなテキスト表示）
+    // タグのHTML生成（色分け対応）
     const tagsHTML = item.tags.map(tag => {
-      const tagClass = tag === 'music' ? 'tag-music' : 'tag-infomation';
-      const tagLabel = tag === 'music' ? 'music' : 'information';
+      let tagClass = 'tag-infomation';
+      let tagLabel = 'information';
+      
+      if (tag === 'music') {
+        tagClass = 'tag-music';
+        tagLabel = 'music';
+      } else if (tag === 'video') {
+        tagClass = 'tag-video';
+        tagLabel = 'video';
+      } else if (tag === 'infomation') {
+        tagClass = 'tag-infomation';
+        tagLabel = 'information';
+      }
+      
       return `<span class="achievement-tag ${tagClass}">${tagLabel}</span>`;
     }).join('');
     
@@ -70,7 +137,7 @@ function displayAchievements(achievementsArray) {
         <div class="achievement-item">
           <div class="achievement-date">${formattedDate}</div>
           <div class="achievement-point"></div>
-          <div class="achievement-content clickable" data-date="${formattedDate}" data-link="${item.link}">
+          <div class="achievement-content clickable" data-link="${item.link}">
             <h3 class="achievement-title">${item.title}</h3>
             <p class="achievement-body">${item.body}</p>
             <div class="achievement-tags">${tagsHTML}</div>
@@ -82,7 +149,7 @@ function displayAchievements(achievementsArray) {
         <div class="achievement-item">
           <div class="achievement-date">${formattedDate}</div>
           <div class="achievement-point"></div>
-          <div class="achievement-content" data-date="${formattedDate}">
+          <div class="achievement-content">
             <h3 class="achievement-title">${item.title}</h3>
             <p class="achievement-body">${item.body}</p>
             <div class="achievement-tags">${tagsHTML}</div>


### PR DESCRIPTION
## 変更内容

### デザイン改善
- 年表デザインを左右交互配置から**縦一列配置**に変更
- 左に日付、右にコンテンツを配置したシンプルで見やすいレイアウト
- コンテンツエリアの幅を最大限活用

### 新機能
- **Videoフィルタを追加**
  - 告知動画などの動画コンテンツをフィルタリング可能に
  - Information、Music、Videoの3つのカテゴリで分類

### タグの色分け
タグごとに自動で色が決定される仕組みを実装：
- **Information**: `rgb(255, 69, 0)` (オレンジレッド)
- **Music**: `rgb(0, 0, 255)` (青)
- **Video**: `rgb(34, 139, 34)` (フォレストグリーン)

### データ更新
- 「30秒でわかる伊吹しろう」自己紹介動画のタグを `infomation` から `video` に変更

### UX改善
- フェードインアニメーションを維持
- レスポンシブデザイン対応（PC/スマートフォン）

## 修正ファイル
- `achievements.html` - Videoフィルタボタン追加
- `css/achievements.css` - 年表レイアウトの全面刷新
- `js/fetch-achievements.js` - タグの色分けロジック実装
- `data/achievements.json` - 動画コンテンツのタグ変更

## スクリーンショット
（必要に応じて追加してください）

## テスト
- [x] PCビューで年表が正しく表示されることを確認
- [x] スマートフォンビューでレイアウトが崩れないことを確認
- [x] 各フィルタ（ALL/Information/Music/Video）が正常に動作することを確認
- [x] タグの色分けが正しく適用されることを確認