### PR TITLE
fix(calendar): Update modal button color to match event color

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -101,8 +101,8 @@
 /* PCのみホバー効果を適用 */
 @media (hover: hover) and (pointer: fine) {
   .nav-btn:hover {
-    background-color: #FF8C00;
-    border-color: #FF8C00;
+    background-color: #FF4500;
+    border-color: #FF4500;
     transform: scale(1.05);
   }
 }
@@ -116,8 +116,8 @@
 /* SPビューでアクティブ状態が残らないように */
 @media (max-width: 768px) {
   .nav-btn:active {
-    background-color: #FF8C00;
-    border-color: #FF8C00;
+    background-color: #FF4500;
+    border-color: #FF4500;
     transform: scale(0.98);
     transition: all 0.1s ease;
   }
@@ -415,7 +415,7 @@
 .event-modal-button {
   display: inline-block;
   padding: 0.75rem 2rem;
-  background-color: #FF8C00;
+  background-color: #FF4500;
   color: #ffffff;
   text-decoration: none;
   border-radius: 8px;


### PR DESCRIPTION
## 変更内容

### カラー統一
- SPビューのモーダルボタンの色を予定の色に合わせて変更
- **変更前**: `#FF8C00` (ダークオレンジ)
- **変更後**: `#FF4500` (オレンジレッド)

### 適用箇所
1. **ナビゲーションボタン（ホバー時）** - PCビュー
2. **ナビゲーションボタン（アクティブ時）** - SPビュー
3. **イベントモーダルボタン** - SPビュー

### 改善効果
- 定期配信チェックで表示される予定の色と統一
- UI全体の色彩に一貫性を持たせる
- 視覚的な調和が向上

## 修正ファイル
- `css/calendar.css`

## テスト
- [x] PCビューでナビゲーションボタンのホバー色を確認
- [x] SPビューでナビゲーションボタンのアクティブ色を確認
- [x] SPビューでモーダルボタンの背景色を確認