### PR TITLE
fix: カレンダーの960px～1090px範囲でのレスポンシブ表示を改善

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -156,9 +156,8 @@
 
 .calendar-grid {
   display: grid;
-  grid-template-columns: repeat(7, minmax(140px, 1fr));
+  grid-template-columns: repeat(7, minmax(120px, 1fr));
   gap: 0;
-  min-width: 980px;
   width: 100%;
 }
 
@@ -477,6 +476,49 @@
 /* ============================================
    レスポンシブ対応
    ============================================ */
+
+/* 960px～1090pxの範囲でカレンダーの幅を調整 */
+@media (min-width: 961px) and (max-width: 1090px) {
+  .calendar-container {
+    padding: 1rem;
+  }
+
+  .calendar-grid {
+    grid-template-columns: repeat(7, minmax(100px, 1fr));
+  }
+
+  .calendar-weekday {
+    font-size: 0.85rem;
+    padding: 0.8rem 0.3rem;
+  }
+
+  .calendar-day {
+    min-height: 100px;
+    padding: 0.4rem;
+  }
+
+  .day-number {
+    font-size: 0.95rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .event-item {
+    font-size: 0.7rem;
+    padding: 0.35rem 0.45rem;
+  }
+
+  .event-time {
+    font-size: 0.6rem;
+  }
+
+  .event-title {
+    font-size: 0.7rem;
+  }
+
+  .event-tag {
+    font-size: 0.55rem;
+  }
+}
 
 @media (max-width: 960px) {
   #calendar-section {

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
 // Service Worker - 伊吹しろう Official Website
 // ============================================
 
-const CACHE_VERSION = 'v1.0.6';
+const CACHE_VERSION = 'v1.0.7';
 const CACHE_NAME = `ibukishirou-${CACHE_VERSION}`;
 
 // キャッシュするリソース


### PR DESCRIPTION
## 概要
カレンダーページで横幅960px～1090pxの範囲において、カレンダーの右端が切れて表示される問題を修正しました。

## 問題
- 960px～1090pxの横幅範囲でカレンダーの右端が切れて表示されていた
- `calendar-grid`が`min-width: 980px`で固定されていたため、画面幅が980px未満になると横スクロールが発生

## 対応内容
### CSS変更（calendar.css）
- ✅ `calendar-grid`の`min-width: 980px`を削除し、`width: 100%`に変更
- ✅ `grid-template-columns`の`minmax`値を`140px`→`120px`に調整
- ✅ 960px～1090pxの範囲で適切に表示される専用メディアクエリを追加
  - カレンダーの各要素（日付セル、イベント表示等）のサイズを最適化
  - 画面幅に合わせてカレンダー全体が縮小されるように対応

### Service Worker更新
- ✅ バージョンを`v1.0.6`→`v1.0.7`に更新（README.mdのルールに従って）

## 動作確認
- [x] 960px以下：SPビューとして正常に表示
- [x] 960px～1090px：カレンダー全体が画面幅に収まり、右端が切れない
- [x] 1090px以上：通常のPC表示

## スクリーンショット
修正前：カレンダーの右端が切れて表示される
修正後：カレンダー全体が画面幅に収まって表示される