### PR TITLE
feat: ローディングアニメーションをトップページのみに限定

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -68,7 +68,6 @@
   <!-- Stylesheet -->
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/calendar.css">
-  <link rel="stylesheet" href="/css/loading.css">
   
   <!-- Remix Icon -->
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.1.0/fonts/remixicon.css" rel="stylesheet">
@@ -76,16 +75,6 @@
 </head>
 <body>
   <!-- ローディング画面 -->
-  <div id="loading-screen">
-    <div class="loading-content">
-      <img src="/assets/img/logo_wolf.webp" alt="Loading..." class="loading-logo">
-      <p class="loading-text">
-        <span class="loading-text-pc">伊吹しろう Official Websiteへようこそ</span>
-        <span class="loading-text-sp">伊吹しろう<br>Official<br>Website<br>へようこそ</span>
-      </p>
-    </div>
-  </div>
-
   <!-- ヘッダー -->
   <header></header>
 
@@ -128,7 +117,6 @@
 
   <!-- JavaScript -->
   <script src="/js/components.js"></script>
-  <script src="/js/loading.js"></script>
   <script src="/js/main.js"></script>
   <script src="/js/breadcrumb.js"></script>
   <script src="/js/calendar.js"></script>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
   
   <!-- Stylesheet -->
   <link rel="stylesheet" href="css/style.css">
-  <link rel="stylesheet" href="css/loading.css">
+  <link rel="stylesheet" href="/css/loading.css">
   
   <!-- Remix Icon -->
   <link href="https://cdn.jsdelivr.net/npm/remixicon@4.1.0/fonts/remixicon.css" rel="stylesheet">
@@ -101,7 +101,7 @@
   <!-- ローディング画面 -->
   <div id="loading-screen">
     <div class="loading-content">
-      <img src="assets/img/logo_wolf.webp" alt="Loading..." class="loading-logo">
+      <img src="/assets/img/logo_wolf.webp" alt="Loading..." class="loading-logo">
       <p class="loading-text">
         <span class="loading-text-pc">伊吹しろう Official Websiteへようこそ</span>
         <span class="loading-text-sp">伊吹しろう<br>Official<br>Website<br>へようこそ</span>
@@ -173,7 +173,7 @@
 
   <!-- JavaScript -->
   <script src="js/components.js"></script>
-  <script src="js/loading.js"></script>
+  <script src="/js/loading.js"></script>
   <script src="js/main.js"></script>
   <script src="js/fetch-links.js"></script>
   <script>


### PR DESCRIPTION
## 概要

トップページ(`/`)にアクセスした際のみローディングアニメーションを表示し、他のページ(`/profile`, `/calendar`等)では即座にコンテンツを表示するように変更しました。

---

## 変更内容

### 📄 **calendar/index.html**
以下を削除してローディングアニメーションを完全除去：
- ✅ ローディング画面HTML (`#loading-screen`要素)
- ✅ `/css/loading.css` 読み込み
- ✅ `/js/loading.js` 読み込み

### 🏠 **index.html (トップページ)**
ローディングアニメーションを維持：
- ✅ ローディング画面HTMLそのまま
- ✅ パスをルート相対パスに修正
  - `css/loading.css` → `/css/loading.css`
  - `assets/img/logo_wolf.webp` → `/assets/img/logo_wolf.webp`
  - `js/loading.js` → `/js/loading.js`

---

## 動作

### ✨ **トップページ (/)**
- 初回アクセス時: ローディングアニメーション表示（2秒間）
- 2回目以降: ローディングなし（セッションストレージで管理）

### ⚡ **その他のページ (/profile, /calendar, etc.)**
- すべてのアクセスで即座にコンテンツ表示
- ローディングアニメーションなし

---

## メリット

1. **UX改善**
   - プロフィールやカレンダーなど、直接アクセスした際の待ち時間を削減
   - サイト内遷移がスムーズに

2. **トップページの特別感維持**
   - 初回訪問時のウェルカム体験は維持
   - ブランディング効果を保持

3. **パフォーマンス向上**
   - 不要なCSS/JS読み込みを削減
   - ページ表示速度が向上

---

## 影響範囲

- ✅ トップページ以外のローディング体験が改善
- ✅ 既存のトップページ動作は維持
- ✅ 後方互換性あり

---

## テスト項目

- [ ] トップページ(`/`)で初回アクセス時にローディング表示
- [ ] トップページ(`/`)で2回目以降アクセス時にローディングなし
- [ ] `/profile`で即座に表示
- [ ] `/calendar`で即座に表示
- [ ] `/achievements`で即座に表示
- [ ] 他のページでも即座に表示

---

**レビューをお願いします！**